### PR TITLE
Melhora texto dinamico no Plotly

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -77,36 +77,28 @@ for empresa, grupo in df.groupby("EMPRESA"):
     )
 
 # 2. Textos (origem e destino)
+LIMIAR_TEXTO = 4  # horas
 for empresa, grupo in df.groupby("EMPRESA"):
-    fig.add_trace(go.Bar(
-        x=grupo["DURACAO_H"],
-        y=grupo["VIAGEM"],
-        base=grupo["HORA_ABSOLUTA"],
-        orientation="h",
-        marker=dict(color='rgba(0,0,0,0)'),
-        text=grupo["ORIGEM"],
-        textposition="inside",
-        insidetextanchor="start",
-        textfont=dict(size=12, color="black", family="Arial Black"),
-        showlegend=False,
-        hoverinfo="skip",
-        xaxis="x2"
-    ))
-
-    fig.add_trace(go.Bar(
-        x=grupo["DURACAO_H"],
-        y=grupo["VIAGEM"],
-        base=grupo["HORA_ABSOLUTA"],
-        orientation="h",
-        marker=dict(color='rgba(0,0,0,0)'),
-        text=grupo["DESTINO"],
-        textposition="inside",
-        insidetextanchor="end",
-        textfont=dict(size=12, color="black", family="Arial Black"),
-        showlegend=False,
-        hoverinfo="skip",
-        xaxis="x2"
-    ))
+    textos = [
+        f"{o} → {d}" if dur >= LIMIAR_TEXTO else d
+        for o, d, dur in zip(grupo["ORIGEM"], grupo["DESTINO"], grupo["DURACAO_H"])
+    ]
+    fig.add_trace(
+        go.Bar(
+            x=grupo["DURACAO_H"],
+            y=grupo["VIAGEM"],
+            base=grupo["HORA_ABSOLUTA"],
+            orientation="h",
+            marker=dict(color="rgba(0,0,0,0)"),
+            text=textos,
+            textposition="inside",
+            insidetextanchor="middle",
+            textfont=dict(size=12, color="black", family="Arial Black"),
+            showlegend=False,
+            hoverinfo="skip",
+            xaxis="x2",
+        )
+    )
 
 # === GRADE DE HORAS E DIAS ===
 x_ticks = list(range(0, 24 * 9 + 1))


### PR DESCRIPTION
## Summary
- exibe `ORIGEM → DESTINO` dentro dos blocos quando a duração é maior que o limiar
- mostra apenas o destino nos blocos curtos para evitar sobreposições

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e91e6c3ac832693f6f861725c22bd