### PR TITLE
Melhora texto dinamico no Plotly

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -77,36 +77,45 @@ for empresa, grupo in df.groupby("EMPRESA"):
     )
 
 # 2. Textos (origem e destino)
+LIMIAR_TEXTO = 8  # horas
 for empresa, grupo in df.groupby("EMPRESA"):
-    fig.add_trace(go.Bar(
-        x=grupo["DURACAO_H"],
-        y=grupo["VIAGEM"],
-        base=grupo["HORA_ABSOLUTA"],
-        orientation="h",
-        marker=dict(color='rgba(0,0,0,0)'),
-        text=grupo["ORIGEM"],
-        textposition="inside",
-        insidetextanchor="start",
-        textfont=dict(size=12, color="black", family="Arial Black"),
-        showlegend=False,
-        hoverinfo="skip",
-        xaxis="x2"
-    ))
+    textos_origem = [
+        origem if dur >= LIMIAR_TEXTO else ""
+        for origem, dur in zip(grupo["ORIGEM"], grupo["DURACAO_H"])
+    ]
+    fig.add_trace(
+        go.Bar(
+            x=grupo["DURACAO_H"],
+            y=grupo["VIAGEM"],
+            base=grupo["HORA_ABSOLUTA"],
+            orientation="h",
+            marker=dict(color="rgba(0,0,0,0)"),
+            text=textos_origem,
+            textposition="inside",
+            insidetextanchor="start",
+            textfont=dict(size=12, color="black", family="Arial Black"),
+            showlegend=False,
+            hoverinfo="skip",
+            xaxis="x2",
+        )
+    )
 
-    fig.add_trace(go.Bar(
-        x=grupo["DURACAO_H"],
-        y=grupo["VIAGEM"],
-        base=grupo["HORA_ABSOLUTA"],
-        orientation="h",
-        marker=dict(color='rgba(0,0,0,0)'),
-        text=grupo["DESTINO"],
-        textposition="inside",
-        insidetextanchor="end",
-        textfont=dict(size=12, color="black", family="Arial Black"),
-        showlegend=False,
-        hoverinfo="skip",
-        xaxis="x2"
-    ))
+    fig.add_trace(
+        go.Bar(
+            x=grupo["DURACAO_H"],
+            y=grupo["VIAGEM"],
+            base=grupo["HORA_ABSOLUTA"],
+            orientation="h",
+            marker=dict(color="rgba(0,0,0,0)"),
+            text=grupo["DESTINO"],
+            textposition="inside",
+            insidetextanchor="end",
+            textfont=dict(size=12, color="black", family="Arial Black"),
+            showlegend=False,
+            hoverinfo="skip",
+            xaxis="x2",
+        )
+    )
 
 # === GRADE DE HORAS E DIAS ===
 x_ticks = list(range(0, 24 * 9 + 1))


### PR DESCRIPTION
## Summary
- adjust dynamic text logic
- only show origin text in wide bars (>=8h) and always show destination
- keep original left/right placement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e91e6c3ac832693f6f861725c22bd